### PR TITLE
Addition of precision parameter for memory constrained clustering

### DIFF
--- a/fastcluster.py
+++ b/fastcluster.py
@@ -280,7 +280,7 @@ mtridx = {'euclidean'      :  0,
 booleanmetrics = ('yule', 'matching', 'dice', 'kulsinski', 'rogerstanimoto',
                   'sokalmichener', 'russellrao', 'sokalsneath', 'kulsinski')
 
-def linkage_vector(X, method='single', metric='euclidean', extraarg=None):
+def linkage_vector(X, method='single', metric='euclidean', extraarg=None, low_precision=False):
     r'''Hierarchical (agglomerative) clustering on Euclidean data.
 
 Compared to the 'linkage' method, 'linkage_vector' uses a memory-saving
@@ -463,6 +463,7 @@ metric='matching':
   (False, True) but the Hamming distance is 0.5.
 
 metric='sokalmichener' is an alias for 'matching'.'''
+    dtype = single_ if low_precision else double
     if method=='single':
         assert metric!='USER'
         if metric in ('hamming', 'jaccard'):
@@ -473,10 +474,10 @@ metric='sokalmichener' is an alias for 'matching'.'''
         X = array(X, dtype=dtype, copy=False, order='C', subok=True)
     else:
         assert metric=='euclidean'
-        X = array(X, dtype=single_, copy=(method=='ward'), order='C', subok=True)
+        X = array(X, dtype=dtype, copy=(method=='ward'), order='C', subok=True)
     assert X.ndim==2
     N = len(X)
-    Z = empty((N-1,4), dtype=single_)
+    Z = empty((N-1,4), dtype=dtype)
 
     if metric=='seuclidean':
         if extraarg is None:
@@ -486,7 +487,7 @@ metric='sokalmichener' is an alias for 'matching'.'''
             extraarg = inv(cov(X, rowvar=False))
         # instead of the inverse covariance matrix, pass the matrix product
         # with the data matrix!
-        extraarg = array(dot(X,extraarg),dtype=single_, copy=False, order='C', subok=True)
+        extraarg = array(dot(X,extraarg),dtype=dtype, copy=False, order='C', subok=True)
     elif metric=='correlation':
         X = X-expand_dims(X.mean(axis=1),1)
         metric='cosine'

--- a/fastcluster.py
+++ b/fastcluster.py
@@ -151,7 +151,7 @@ follows:
      contains all original input points.
 
 The output of linkage is stepwise dendrogram, which is represented as an
-(N−1)×4 NumPy array with singleing point entries (dtype=numpy.double).
+(N−1)×4 NumPy array with floating point entries (dtype=numpy.double).
 The first two columns contain the node indices which are joined in each
 step. The input nodes are labeled 0,...,N−1, and the newly generated
 nodes have the labels N,...,2N−2. The third column contains the distance
@@ -307,7 +307,7 @@ Therefore, the available metrics with their definitions are listed below
 as a reference. The symbols u and v mostly denote vectors in R^D with
 coordinates u_j and v_j respectively. See below for additional metrics
 for Boolean vectors. Unless otherwise stated, the input array X is
-converted to a singleing point array (X.dtype==numpy.single) if it does
+converted to a floating point array (X.dtype==numpy.single) if it does
 not have already the required data type. Some metrics accept Boolean
 input; in this case this is stated explicitly below.
 
@@ -388,7 +388,7 @@ metric='braycurtis'
     d(u,v) = (\sum_j |u_j-v_j|) / (\sum_j |u_j+v_j|)
 
 metric=(user function): The parameter metric may also be a function
-  which accepts two NumPy singleing point vectors and returns a number.
+  which accepts two NumPy floating point vectors and returns a number.
   Eg. the Euclidean distance could be emulated with
 
     fn = lambda u, v: numpy.sqrt(((u-v)*(u-v)).sum())

--- a/fastcluster.py
+++ b/fastcluster.py
@@ -25,6 +25,9 @@ __version__ = '.'.join(__version_info__)
 
 from numpy import double, empty, array, ndarray, var, cov, dot, expand_dims, \
     ceil, sqrt
+
+from numpy import single as single_
+
 from numpy.linalg import inv
 try:
     from scipy.spatial.distance import pdist
@@ -88,7 +91,7 @@ Apart from the argument 'preserve_input', the method has the same input
 parameters and output format as the functions of the same name in the
 module scipy.cluster.hierarchy.
 
-The argument X is preferably a NumPy array with floating point entries
+The argument X is preferably a NumPy array with singleing point entries
 (X.dtype==numpy.double). Any other data format will be converted before
 it is processed.
 
@@ -145,7 +148,7 @@ follows:
      contains all original input points.
 
 The output of linkage is stepwise dendrogram, which is represented as an
-(N−1)×4 NumPy array with floating point entries (dtype=numpy.double).
+(N−1)×4 NumPy array with singleing point entries (dtype=numpy.double).
 The first two columns contain the node indices which are joined in each
 step. The input nodes are labeled 0,...,N−1, and the newly generated
 nodes have the labels N,...,2N−2. The third column contains the distance
@@ -231,7 +234,7 @@ and simply ignores the mask.'''
     if X.ndim==1:
         if method=='single':
             preserve_input = False
-        X = array(X, dtype=double, copy=preserve_input, order='C', subok=True)
+        X = array(X, dtype=single_, copy=preserve_input, order='C', subok=True)
         NN = len(X)
         N = int(ceil(sqrt(NN*2)))
         if (N*(N-1)//2) != NN:
@@ -241,8 +244,8 @@ and simply ignores the mask.'''
         assert X.ndim==2
         N = len(X)
         X = pdist(X, metric=metric)
-        X = array(X, dtype=double, copy=False, order='C', subok=True)
-    Z = empty((N-1,4))
+        X = array(X, dtype=single_, copy=False, order='C', subok=True)
+    Z = empty((N-1,4), dtype=single_)
     if N > 1:
         linkage_wrap(N, X, Z, mthidx[method])
     return Z
@@ -300,7 +303,7 @@ Therefore, the available metrics with their definitions are listed below
 as a reference. The symbols u and v mostly denote vectors in R^D with
 coordinates u_j and v_j respectively. See below for additional metrics
 for Boolean vectors. Unless otherwise stated, the input array X is
-converted to a floating point array (X.dtype==numpy.double) if it does
+converted to a singleing point array (X.dtype==numpy.single) if it does
 not have already the required data type. Some metrics accept Boolean
 input; in this case this is stated explicitly below.
 
@@ -381,7 +384,7 @@ metric='braycurtis'
     d(u,v) = (\sum_j |u_j-v_j|) / (\sum_j |u_j+v_j|)
 
 metric=(user function): The parameter metric may also be a function
-  which accepts two NumPy floating point vectors and returns a number.
+  which accepts two NumPy singleing point vectors and returns a number.
   Eg. the Euclidean distance could be emulated with
 
     fn = lambda u, v: numpy.sqrt(((u-v)*(u-v)).sum())
@@ -391,13 +394,13 @@ metric=(user function): The parameter metric may also be a function
 
 metric='hamming': The Hamming distance accepts a Boolean array
   (X.dtype==bool) for efficient storage. Any other data type is
-  converted to numpy.double.
+  converted to numpy.single.
 
     d(u,v) = |{j | u_j≠v_j }|
 
 metric='jaccard': The Jaccard distance accepts a Boolean array
   (X.dtype==bool) for efficient storage. Any other data type is
-  converted to numpy.double.
+  converted to numpy.single.
 
     d(u,v) = |{j | u_j≠v_j }| / |{j | u_j≠0 or v_j≠0 }|
     d(0,0) = 0
@@ -461,16 +464,16 @@ metric='sokalmichener' is an alias for 'matching'.'''
         assert metric!='USER'
         if metric in ('hamming', 'jaccard'):
             X = array(X, copy=False, subok=True)
-            dtype = bool if X.dtype==bool else double
+            dtype = bool if X.dtype==bool else single_
         else:
-            dtype = bool if metric in booleanmetrics else double
+            dtype = bool if metric in booleanmetrics else single_
         X = array(X, dtype=dtype, copy=False, order='C', subok=True)
     else:
         assert metric=='euclidean'
-        X = array(X, dtype=double, copy=(method=='ward'), order='C', subok=True)
+        X = array(X, dtype=single_, copy=(method=='ward'), order='C', subok=True)
     assert X.ndim==2
     N = len(X)
-    Z = empty((N-1,4))
+    Z = empty((N-1,4), dtype=single_)
 
     if metric=='seuclidean':
         if extraarg is None:
@@ -480,7 +483,7 @@ metric='sokalmichener' is an alias for 'matching'.'''
             extraarg = inv(cov(X, rowvar=False))
         # instead of the inverse covariance matrix, pass the matrix product
         # with the data matrix!
-        extraarg = array(dot(X,extraarg),dtype=double, copy=False, order='C', subok=True)
+        extraarg = array(dot(X,extraarg),dtype=single_, copy=False, order='C', subok=True)
     elif metric=='correlation':
         X = X-expand_dims(X.mean(axis=1),1)
         metric='cosine'

--- a/fastcluster.py
+++ b/fastcluster.py
@@ -83,7 +83,7 @@ mthidx = {'single'   : 0,
           'centroid' : 5,
           'median'   : 6 }
 
-def linkage(X, method='single', metric='euclidean', preserve_input=True, low_precision=False):
+def linkage(X, method='single', metric='euclidean', preserve_input=True, high_precision=True):
     r'''Hierarchical, agglomerative clustering on a dissimilarity matrix or on
 Euclidean data.
 
@@ -94,8 +94,9 @@ module scipy.cluster.hierarchy.
 The argument X is preferably a NumPy array with floating point entries
 (X.dtype==numpy.double). However, single-precision floating point
 (X.dtype==numpy.single) values are also accepted and processed 
-as such when 'low_precision' is set to True. Any lower precision format 
-will be upscaled to the either numpy.double or numpy.single.
+as such when 'high_precision' is set to False. Any lower precision format 
+will be upscaled to the either numpy.double or numpy.single depending 
+on the high_precision flag.
 
 If X is a one-dimensional array, it is considered a condensed matrix of
 pairwise dissimilarities in the format which is returned by
@@ -232,7 +233,7 @@ raised.
 
 The linkage method does not treat NumPy's masked arrays as special
 and simply ignores the mask.'''
-    dtype = single_ if low_precision else double
+    dtype = double if high_precision else single_
     X = array(X, copy=False, subok=True)
     if X.ndim==1:
         if method=='single':
@@ -250,8 +251,8 @@ and simply ignores the mask.'''
         X = array(X, dtype=dtype, copy=False, order='C', subok=True)
     Z = empty((N-1,4), dtype=dtype)
     if N > 1:
-        linkage_wrap(N, X, Z, mthidx[method])
-    return Z
+        linkage_wrap(N, X, Z, mthidx[method], high_precision)
+    return Z.astype(double)
 
 # This dictionary must agree with the enum metric_codes in fastcluster_python.cpp.
 mtridx = {'euclidean'      :  0,
@@ -280,7 +281,7 @@ mtridx = {'euclidean'      :  0,
 booleanmetrics = ('yule', 'matching', 'dice', 'kulsinski', 'rogerstanimoto',
                   'sokalmichener', 'russellrao', 'sokalsneath', 'kulsinski')
 
-def linkage_vector(X, method='single', metric='euclidean', extraarg=None, low_precision=False):
+def linkage_vector(X, method='single', metric='euclidean', extraarg=None, high_precision=True):
     r'''Hierarchical (agglomerative) clustering on Euclidean data.
 
 Compared to the 'linkage' method, 'linkage_vector' uses a memory-saving
@@ -463,14 +464,14 @@ metric='matching':
   (False, True) but the Hamming distance is 0.5.
 
 metric='sokalmichener' is an alias for 'matching'.'''
-    dtype = single_ if low_precision else double
+    dtype = double if high_precision else single
     if method=='single':
         assert metric!='USER'
         if metric in ('hamming', 'jaccard'):
             X = array(X, copy=False, subok=True)
-            dtype = bool if X.dtype==bool else single_
+            dtype = bool if X.dtype==bool else dtype
         else:
-            dtype = bool if metric in booleanmetrics else single_
+            dtype = bool if metric in booleanmetrics else dtype
         X = array(X, dtype=dtype, copy=False, order='C', subok=True)
     else:
         assert metric=='euclidean'
@@ -497,5 +498,5 @@ metric='sokalmichener' is an alias for 'matching'.'''
     elif metric!='minkowski':
         assert extraarg is None
     if N > 1:
-        linkage_vector_wrap(X, Z, mthidx[method], mtridx[metric], extraarg)
-    return Z
+        linkage_vector_wrap(X, Z, mthidx[method], mtridx[metric], extraarg, high_precision)
+    return Z.astype(double)

--- a/fastcluster.py
+++ b/fastcluster.py
@@ -83,7 +83,7 @@ mthidx = {'single'   : 0,
           'centroid' : 5,
           'median'   : 6 }
 
-def linkage(X, method='single', metric='euclidean', preserve_input=True):
+def linkage(X, method='single', metric='euclidean', preserve_input=True, low_precision=False):
     r'''Hierarchical, agglomerative clustering on a dissimilarity matrix or on
 Euclidean data.
 
@@ -91,9 +91,11 @@ Apart from the argument 'preserve_input', the method has the same input
 parameters and output format as the functions of the same name in the
 module scipy.cluster.hierarchy.
 
-The argument X is preferably a NumPy array with singleing point entries
-(X.dtype==numpy.double). Any other data format will be converted before
-it is processed.
+The argument X is preferably a NumPy array with floating point entries
+(X.dtype==numpy.double). However, single-precision floating point
+(X.dtype==numpy.single) values are also accepted and processed 
+as such when 'low_precision' is set to True. Any lower precision format 
+will be upscaled to the either numpy.double or numpy.single.
 
 If X is a one-dimensional array, it is considered a condensed matrix of
 pairwise dissimilarities in the format which is returned by
@@ -230,11 +232,12 @@ raised.
 
 The linkage method does not treat NumPy's masked arrays as special
 and simply ignores the mask.'''
+    dtype = single_ if low_precision else double
     X = array(X, copy=False, subok=True)
     if X.ndim==1:
         if method=='single':
             preserve_input = False
-        X = array(X, dtype=single_, copy=preserve_input, order='C', subok=True)
+        X = array(X, dtype=dtype, copy=preserve_input, order='C', subok=True)
         NN = len(X)
         N = int(ceil(sqrt(NN*2)))
         if (N*(N-1)//2) != NN:
@@ -244,8 +247,8 @@ and simply ignores the mask.'''
         assert X.ndim==2
         N = len(X)
         X = pdist(X, metric=metric)
-        X = array(X, dtype=single_, copy=False, order='C', subok=True)
-    Z = empty((N-1,4), dtype=single_)
+        X = array(X, dtype=dtype, copy=False, order='C', subok=True)
+    Z = empty((N-1,4), dtype=dtype)
     if N > 1:
         linkage_wrap(N, X, Z, mthidx[method])
     return Z

--- a/fastcluster.py
+++ b/fastcluster.py
@@ -151,7 +151,7 @@ follows:
      contains all original input points.
 
 The output of linkage is stepwise dendrogram, which is represented as an
-(N−1)×4 NumPy array with floating point entries (dtype=numpy.double).
+(N−1)×4 NumPy array with singleing point entries (dtype=numpy.double).
 The first two columns contain the node indices which are joined in each
 step. The input nodes are labeled 0,...,N−1, and the newly generated
 nodes have the labels N,...,2N−2. The third column contains the distance
@@ -307,7 +307,7 @@ Therefore, the available metrics with their definitions are listed below
 as a reference. The symbols u and v mostly denote vectors in R^D with
 coordinates u_j and v_j respectively. See below for additional metrics
 for Boolean vectors. Unless otherwise stated, the input array X is
-converted to a floating point array (X.dtype==numpy.single) if it does
+converted to a singleing point array (X.dtype==numpy.single) if it does
 not have already the required data type. Some metrics accept Boolean
 input; in this case this is stated explicitly below.
 
@@ -388,7 +388,7 @@ metric='braycurtis'
     d(u,v) = (\sum_j |u_j-v_j|) / (\sum_j |u_j+v_j|)
 
 metric=(user function): The parameter metric may also be a function
-  which accepts two NumPy floating point vectors and returns a number.
+  which accepts two NumPy singleing point vectors and returns a number.
   Eg. the Euclidean distance could be emulated with
 
     fn = lambda u, v: numpy.sqrt(((u-v)*(u-v)).sum())
@@ -464,7 +464,7 @@ metric='matching':
   (False, True) but the Hamming distance is 0.5.
 
 metric='sokalmichener' is an alias for 'matching'.'''
-    dtype = double if high_precision else single
+    dtype = double if high_precision else single_
     if method=='single':
         assert metric!='USER'
         if metric in ('hamming', 'jaccard'):

--- a/src/fastcluster.cpp
+++ b/src/fastcluster.cpp
@@ -149,7 +149,7 @@ typedef int_fast32_t t_index;
 #if (INT_MAX > MAX_INDEX)
 #error The integer format "int" must not have a greater range than "t_index".
 #endif
-typedef double t_float;
+typedef float t_float;
 
 /* Method codes.
 

--- a/src/fastcluster.cpp
+++ b/src/fastcluster.cpp
@@ -71,17 +71,7 @@
 #include <stdexcept> // for std::runtime_error
 #include <string> // for std::string
 
-#include <cfloat> // also for DBL_MAX, DBL_MIN
-template<typename T>
-constexpr int get_mantissa_digits();
-template<>
-constexpr int get_mantissa_digits<float>() {
-    return FLT_MANT_DIG;
-}
-template<>
-constexpr int get_mantissa_digits<double>() {
-    return DBL_MANT_DIG;
-}
+#include <cfloat>
 
 #ifndef LONG_MAX
 #include <climits>
@@ -242,7 +232,7 @@ inline bool operator< (const node<T> a, const node<T> b) {
 template<typename T>
 class cluster_result {
 private:
-  auto_array_ptr<node<T>> Z; // Use node<T> here
+  auto_array_ptr<node<T> > Z; // Use node<T> here
   t_index pos;
 
 public:
@@ -1374,7 +1364,7 @@ static void generic_linkage(const t_index N, T * const D, t_members * const memb
   Clustering methods for vector data
 */
 
-template <typename t_dissimilarity, typename T>
+template <typename T, typename t_dissimilarity>
 static void MST_linkage_core_vector(const t_index N,
                                     t_dissimilarity & dist,
                                     cluster_result<T> & Z2) {
@@ -1447,7 +1437,7 @@ static void MST_linkage_core_vector(const t_index N,
   }
 }
 
-template <method_codes_vector method, typename t_dissimilarity, typename T>
+template <method_codes_vector method, typename T, typename t_dissimilarity>
 static void generic_linkage_vector(const t_index N,
                                    t_dissimilarity & dist,
                                    cluster_result<T> & Z2) {
@@ -1646,7 +1636,7 @@ static void generic_linkage_vector(const t_index N,
   }
 }
 
-template <method_codes_vector method, typename t_dissimilarity, typename T>
+template <method_codes_vector method, typename T, typename t_dissimilarity>
 static void generic_linkage_vector_alternative(const t_index N,
                                                t_dissimilarity & dist,
                                                cluster_result<T> & Z2) {

--- a/src/fastcluster_python.cpp
+++ b/src/fastcluster_python.cpp
@@ -47,17 +47,17 @@
 
    The '#include <cmath>' seems to cure the problem.
 */
-//#include <cmath>
-#define fc_isnan(X) ((X)!=(X))
+// #include <cmath>
+#define fc_isnan(X) ((X) != (X))
 
 // There is Py_IS_NAN but it is so much slower on my x86_64 system with GCC!
 
-#include <cmath> // for std::abs, std::pow, std::sqrt
-#include <cstddef> // for std::ptrdiff_t
-#include <limits> // for std::numeric_limits<...>::infinity()
 #include <algorithm> // for std::stable_sort
-#include <new> // for std::bad_alloc
+#include <cmath>     // for std::abs, std::pow, std::sqrt
+#include <cstddef>   // for std::ptrdiff_t
 #include <exception> // for std::exception
+#include <limits>    // for std::numeric_limits<...>::infinity()
+#include <new>       // for std::bad_alloc
 
 #include "fastcluster.cpp"
 
@@ -79,24 +79,21 @@
 /*
   Convenience class for the output array: automatic counter.
 */
-class linkage_output {
+template <typename T> class linkage_output {
 private:
-  t_float * Z;
+  T *Z;
 
 public:
-  linkage_output(t_float * const Z_)
-    : Z(Z_)
-  {}
+  linkage_output(T *const Z_) : Z(Z_) {}
 
-  void append(const t_index node1, const t_index node2, const t_float dist,
-              const t_float size) {
-    if (node1<node2) {
-      *(Z++) = static_cast<t_float>(node1);
-      *(Z++) = static_cast<t_float>(node2);
-    }
-    else {
-      *(Z++) = static_cast<t_float>(node2);
-      *(Z++) = static_cast<t_float>(node1);
+  void append(const t_index node1, const t_index node2, const T dist,
+              const T size) {
+    if (node1 < node2) {
+      *(Z++) = static_cast<T>(node1);
+      *(Z++) = static_cast<T>(node2);
+    } else {
+      *(Z++) = static_cast<T>(node2);
+      *(Z++) = static_cast<T>(node1);
     }
     *(Z++) = dist;
     *(Z++) = size;
@@ -111,27 +108,27 @@ public:
 */
 // The size of a node is either 1 (a single point) or is looked up from
 // one of the clusters.
-#define size_(r_) ( ((r_<N) ? 1 : Z_(r_-N,3)) )
+#define size_(r_) (((r_ < N) ? 1 : Z_(r_ - N, 3)))
 
-template <const bool sorted>
-static void generate_SciPy_dendrogram(t_float * const Z, cluster_result & Z2, const t_index N) {
+template <const bool sorted, typename T>
+static void generate_SciPy_dendrogram(T *const Z, cluster_result<T> &Z2,
+                                      const t_index N) {
   // The array "nodes" is a union-find data structure for the cluster
   // identities (only needed for unsorted cluster_result input).
   union_find nodes(sorted ? 0 : N);
   if (!sorted) {
-    std::stable_sort(Z2[0], Z2[N-1]);
+    std::stable_sort(Z2[0], Z2[N - 1]);
   }
 
-  linkage_output output(Z);
+  linkage_output<T> output(Z);
   t_index node1, node2;
 
-  for (node const * NN=Z2[0]; NN!=Z2[N-1]; ++NN) {
+  for (node<T> const *NN = Z2[0]; NN != Z2[N - 1]; ++NN) {
     // Get two data points whose clusters are merged in step i.
     if (sorted) {
       node1 = NN->node1;
       node2 = NN->node2;
-    }
-    else {
+    } else {
       // Find the cluster identifiers for these points.
       node1 = nodes.Find(NN->node1);
       node2 = nodes.Find(NN->node2);
@@ -139,21 +136,22 @@ static void generate_SciPy_dendrogram(t_float * const Z, cluster_result & Z2, co
       // children of a new node.
       nodes.Union(node1, node2);
     }
-    output.append(node1, node2, NN->dist, size_(node1)+size_(node2));
+    output.append(node1, node2, NN->dist, size_(node1) + size_(node2));
   }
 }
 
 /*
   Python interface code
 */
-static PyObject * linkage_wrap(PyObject * const self, PyObject * const args);
-static PyObject * linkage_vector_wrap(PyObject * const self, PyObject * const args);
+static PyObject *linkage_wrap(PyObject *const self, PyObject *const args);
+static PyObject *linkage_vector_wrap(PyObject *const self,
+                                     PyObject *const args);
 
 // List the C++ methods that this extension provides.
 static PyMethodDef _fastclusterWrapMethods[] = {
-  {"linkage_wrap", linkage_wrap, METH_VARARGS, NULL},
-  {"linkage_vector_wrap", linkage_vector_wrap, METH_VARARGS, NULL},
-  {NULL, NULL, 0, NULL}    /* Sentinel - marks the end of this structure */
+    {"linkage_wrap", linkage_wrap, METH_VARARGS, NULL},
+    {"linkage_vector_wrap", linkage_vector_wrap, METH_VARARGS, NULL},
+    {NULL, NULL, 0, NULL} /* Sentinel - marks the end of this structure */
 };
 
 /* Tell Python about these methods.
@@ -163,14 +161,16 @@ static PyMethodDef _fastclusterWrapMethods[] = {
 #if PY_VERSION_HEX >= 0x03000000
 
 static struct PyModuleDef fastclustermodule = {
-  PyModuleDef_HEAD_INIT,
-  "_fastcluster",
-  NULL, // no module documentation
-  -1,  /* size of per-interpreter state of the module,
-          or -1 if the module keeps state in global variables. */
-  _fastclusterWrapMethods,
-  NULL, NULL, NULL, NULL
-};
+    PyModuleDef_HEAD_INIT,
+    "_fastcluster",
+    NULL, // no module documentation
+    -1,   /* size of per-interpreter state of the module,
+             or -1 if the module keeps state in global variables. */
+    _fastclusterWrapMethods,
+    NULL,
+    NULL,
+    NULL,
+    NULL};
 
 /* Make the interface initalization routines visible in the shared object
  * file.
@@ -180,12 +180,12 @@ static struct PyModuleDef fastclustermodule = {
 #endif
 
 PyMODINIT_FUNC PyInit__fastcluster(void) {
-  PyObject * m;
+  PyObject *m;
   m = PyModule_Create(&fastclustermodule);
   if (!m) {
     return NULL;
   }
-  import_array();  // Must be present for NumPy. Called first after above line.
+  import_array(); // Must be present for NumPy. Called first after above line.
   return m;
 }
 
@@ -193,15 +193,15 @@ PyMODINIT_FUNC PyInit__fastcluster(void) {
 #pragma GCC visibility pop
 #endif
 
-# else // Python 2.x
+#else // Python 2.x
 
 #if HAVE_VISIBILITY
 #pragma GCC visibility push(default)
 #endif
 
-PyMODINIT_FUNC init_fastcluster(void)  {
-  (void) Py_InitModule("_fastcluster", _fastclusterWrapMethods);
-  import_array();  // Must be present for NumPy. Called first after above line.
+PyMODINIT_FUNC init_fastcluster(void) {
+  (void)Py_InitModule("_fastcluster", _fastclusterWrapMethods);
+  import_array(); // Must be present for NumPy. Called first after above line.
 }
 
 #if HAVE_VISIBILITY
@@ -210,57 +210,58 @@ PyMODINIT_FUNC init_fastcluster(void)  {
 
 #endif // PY_VERSION
 
-class GIL_release
-  {
-  private:
-    // noncopyable
-    GIL_release(GIL_release const &);
-    GIL_release & operator=(GIL_release const &);
-  public:
-    inline
-    GIL_release(bool really = true)
-      : _save(really ? PyEval_SaveThread() : NULL)
-    {
-    }
+class GIL_release {
+private:
+  // noncopyable
+  GIL_release(GIL_release const &);
+  GIL_release &operator=(GIL_release const &);
 
-    inline
-    ~GIL_release()
-    {
-      if (_save)
-        PyEval_RestoreThread(_save);
-    }
+public:
+  inline GIL_release(bool really = true)
+      : _save(really ? PyEval_SaveThread() : NULL) {}
 
-  private:
-    PyThreadState * _save;
-  };
+  inline ~GIL_release() {
+    if (_save)
+      PyEval_RestoreThread(_save);
+  }
+
+private:
+  PyThreadState *_save;
+};
 
 /*
   Interface to Python, part 1:
   The input is a dissimilarity matrix.
 */
 
-static PyObject *linkage_wrap(PyObject * const, PyObject * const args) {
-  PyArrayObject * D, * Z;
+static PyObject *linkage_wrap(PyObject *const, PyObject *const args) {
+  PyArrayObject *D, *Z;
   long int N_ = 0;
   unsigned char method;
+  int high_precision_flag = 0;
 
-  try{
+  try {
 #if HAVE_DIAGNOSTIC
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif
     // Parse the input arguments
-    if (!PyArg_ParseTuple(args, "lO!O!b",
-                          &N_,                // signed long integer
-                          &PyArray_Type, &D, // NumPy array
-                          &PyArray_Type, &Z, // NumPy array
-                          &method)) {        // unsigned char
+    if (!PyArg_ParseTuple(args, "lO!O!bp",
+                          &N_,                     // signed long integer
+                          &PyArray_Type, &D,       // NumPy array
+                          &PyArray_Type, &Z,       // NumPy array
+                          &method,                 // unsigned char
+                          &high_precision_flag)) { // int
       return NULL; // Error if the arguments have the wrong type.
     }
+
+    bool high_precision = high_precision_flag != 0;
+    int T_mant_dig = high_precision ? DBL_MANT_DIG : FLT_MANT_DIG;
+
 #if HAVE_DIAGNOSTIC
 #pragma GCC diagnostic pop
 #endif
-    if (N_ < 1 ) {
+    if (N_ < 1) {
       // N must be at least 1.
       PyErr_SetString(PyExc_ValueError,
                       "At least one element is needed for clustering.");
@@ -273,7 +274,7 @@ static PyObject *linkage_wrap(PyObject * const, PyObject * const args) {
       fit into the data type used for indices.
       (2)
       The largest representable integer, without loss of precision, by a
-      floating point number of type t_float is 2^T_FLOAT_MANT_DIG. Here, we
+      floating point number of type T is 2^T_mant_dig. Here, we
       make sure that all cluster labels from 0 to 2N-2 in the output can be
       accurately represented by a floating point number.
 
@@ -281,98 +282,153 @@ static PyObject *linkage_wrap(PyObject * const, PyObject * const args) {
       a warning ("shift count >= width of type") on systems where "long int"
       is 32 bits wide.
     */
-    if (N_ > MAX_INDEX/4 ||
-        static_cast<int64_t>(N_-1)>>(T_FLOAT_MANT_DIG-1) > 0) {
-      PyErr_SetString(PyExc_ValueError,
-                      "Data is too big, index overflow.");
+    if (N_ > MAX_INDEX / 4 ||
+        static_cast<int64_t>(N_ - 1) >> (T_mant_dig - 1) > 0) {
+      PyErr_SetString(PyExc_ValueError, "Data is too big, index overflow.");
       return NULL;
     }
+
     t_index N = static_cast<t_index>(N_);
 
     // Allow threads!
     GIL_release G;
 
-    t_float * const D_ = reinterpret_cast<t_float *>(PyArray_DATA(D));
-    cluster_result Z2(N-1);
-    auto_array_ptr<t_index> members;
-    // For these methods, the distance update formula needs the number of
-    // data points in a cluster.
-    if (method==METHOD_METR_AVERAGE ||
-        method==METHOD_METR_WARD ||
-        method==METHOD_METR_CENTROID) {
-      members.init(N, 1);
-    }
-    // Operate on squared distances for these methods.
-    if (method==METHOD_METR_WARD ||
-        method==METHOD_METR_CENTROID ||
-        method==METHOD_METR_MEDIAN) {
-      for (t_float * DD = D_; DD!=D_+static_cast<std::ptrdiff_t>(N)*(N-1)/2;
-           ++DD)
-        *DD *= *DD;
+    if (high_precision) {
+      using T = double;
+      T *const D_ = reinterpret_cast<T *>(PyArray_DATA(D));
+      cluster_result<T> Z2(N - 1);
+      auto_array_ptr<t_index> members;
+      // For these methods, the distance update formula needs the number of
+      // data points in a cluster.
+      if (method == METHOD_METR_AVERAGE || method == METHOD_METR_WARD ||
+          method == METHOD_METR_CENTROID) {
+        members.init(N, 1);
+      }
+      // Operate on squared distances for these methods.
+      if (method == METHOD_METR_WARD || method == METHOD_METR_CENTROID ||
+          method == METHOD_METR_MEDIAN) {
+        for (T *DD = D_;
+             DD != D_ + static_cast<std::ptrdiff_t>(N) * (N - 1) / 2; ++DD)
+          *DD *= *DD;
+      }
+
+      switch (method) {
+      case METHOD_METR_SINGLE:
+        MST_linkage_core<T>(N, D_, Z2);
+        break;
+      case METHOD_METR_COMPLETE:
+        NN_chain_core<METHOD_METR_COMPLETE, t_index, T>(N, D_, NULL, Z2);
+        break;
+      case METHOD_METR_AVERAGE:
+        NN_chain_core<METHOD_METR_AVERAGE, t_index, T>(N, D_, members, Z2);
+        break;
+      case METHOD_METR_WEIGHTED:
+        NN_chain_core<METHOD_METR_WEIGHTED, t_index, T>(N, D_, NULL, Z2);
+        break;
+      case METHOD_METR_WARD:
+        NN_chain_core<METHOD_METR_WARD, t_index, T>(N, D_, members, Z2);
+        break;
+      case METHOD_METR_CENTROID:
+        generic_linkage<METHOD_METR_CENTROID, t_index, T>(N, D_, members, Z2);
+        break;
+      case METHOD_METR_MEDIAN:
+        generic_linkage<METHOD_METR_MEDIAN, t_index, T>(N, D_, NULL, Z2);
+        break;
+      default:
+        throw std::runtime_error(std::string("Invalid method index."));
+      }
+
+      if (method == METHOD_METR_WARD || method == METHOD_METR_CENTROID ||
+          method == METHOD_METR_MEDIAN) {
+        Z2.sqrt();
+      }
+
+      T *const Z_ = reinterpret_cast<T *>(PyArray_DATA(Z));
+      if (method == METHOD_METR_CENTROID || method == METHOD_METR_MEDIAN) {
+        generate_SciPy_dendrogram<true, T>(Z_, Z2, N);
+      } else {
+        generate_SciPy_dendrogram<false, T>(Z_, Z2, N);
+      }
     }
 
-    switch (method) {
-    case METHOD_METR_SINGLE:
-      MST_linkage_core(N, D_, Z2);
-      break;
-    case METHOD_METR_COMPLETE:
-      NN_chain_core<METHOD_METR_COMPLETE, t_index>(N, D_, NULL, Z2);
-      break;
-    case METHOD_METR_AVERAGE:
-      NN_chain_core<METHOD_METR_AVERAGE, t_index>(N, D_, members, Z2);
-      break;
-    case METHOD_METR_WEIGHTED:
-      NN_chain_core<METHOD_METR_WEIGHTED, t_index>(N, D_, NULL, Z2);
-      break;
-    case METHOD_METR_WARD:
-      NN_chain_core<METHOD_METR_WARD, t_index>(N, D_, members, Z2);
-      break;
-    case METHOD_METR_CENTROID:
-      generic_linkage<METHOD_METR_CENTROID, t_index>(N, D_, members, Z2);
-      break;
-    case METHOD_METR_MEDIAN:
-      generic_linkage<METHOD_METR_MEDIAN, t_index>(N, D_, NULL, Z2);
-      break;
-    default:
-      throw std::runtime_error(std::string("Invalid method index."));
-    }
-
-    if (method==METHOD_METR_WARD ||
-        method==METHOD_METR_CENTROID ||
-        method==METHOD_METR_MEDIAN) {
-      Z2.sqrt();
-    }
-
-    t_float * const Z_ = reinterpret_cast<t_float *>(PyArray_DATA(Z));
-    if (method==METHOD_METR_CENTROID ||
-        method==METHOD_METR_MEDIAN) {
-      generate_SciPy_dendrogram<true>(Z_, Z2, N);
-    }
     else {
-      generate_SciPy_dendrogram<false>(Z_, Z2, N);
+      using T = float;
+      T *const D_ = reinterpret_cast<T *>(PyArray_DATA(D));
+      cluster_result<T> Z2(N - 1);
+      auto_array_ptr<t_index> members;
+      // For these methods, the distance update formula needs the number of
+      // data points in a cluster.
+      if (method == METHOD_METR_AVERAGE || method == METHOD_METR_WARD ||
+          method == METHOD_METR_CENTROID) {
+        members.init(N, 1);
+      }
+      // Operate on squared distances for these methods.
+      if (method == METHOD_METR_WARD || method == METHOD_METR_CENTROID ||
+          method == METHOD_METR_MEDIAN) {
+        for (T *DD = D_;
+             DD != D_ + static_cast<std::ptrdiff_t>(N) * (N - 1) / 2; ++DD)
+          *DD *= *DD;
+      }
+
+      switch (method) {
+      case METHOD_METR_SINGLE:
+        MST_linkage_core<T>(N, D_, Z2);
+        break;
+      case METHOD_METR_COMPLETE:
+        NN_chain_core<METHOD_METR_COMPLETE, t_index, T>(N, D_, NULL, Z2);
+        break;
+      case METHOD_METR_AVERAGE:
+        NN_chain_core<METHOD_METR_AVERAGE, t_index, T>(N, D_, members, Z2);
+        break;
+      case METHOD_METR_WEIGHTED:
+        NN_chain_core<METHOD_METR_WEIGHTED, t_index, T>(N, D_, NULL, Z2);
+        break;
+      case METHOD_METR_WARD:
+        NN_chain_core<METHOD_METR_WARD, t_index, T>(N, D_, members, Z2);
+        break;
+      case METHOD_METR_CENTROID:
+        generic_linkage<METHOD_METR_CENTROID, t_index, T>(N, D_, members, Z2);
+        break;
+      case METHOD_METR_MEDIAN:
+        generic_linkage<METHOD_METR_MEDIAN, t_index, T>(N, D_, NULL, Z2);
+        break;
+      default:
+        throw std::runtime_error(std::string("Invalid method index."));
+      }
+
+      if (method == METHOD_METR_WARD || method == METHOD_METR_CENTROID ||
+          method == METHOD_METR_MEDIAN) {
+        Z2.sqrt();
+      }
+
+      T *const Z_ = reinterpret_cast<T *>(PyArray_DATA(Z));
+      if (method == METHOD_METR_CENTROID || method == METHOD_METR_MEDIAN) {
+        generate_SciPy_dendrogram<true, T>(Z_, Z2, N);
+      } else {
+        generate_SciPy_dendrogram<false, T>(Z_, Z2, N);
+      }
     }
   } // try
-  catch (const std::bad_alloc&) {
+  catch (const std::bad_alloc &) {
     return PyErr_NoMemory();
-  }
-  catch(const std::exception& e){
+  } catch (const std::exception &e) {
     PyErr_SetString(PyExc_EnvironmentError, e.what());
     return NULL;
-  }
-  catch(const nan_error&){
+  } catch (const nan_error &) {
     PyErr_SetString(PyExc_FloatingPointError, "NaN dissimilarity value.");
     return NULL;
   }
-  #ifdef FE_INVALID
-  catch(const fenv_error&){
+#ifdef FE_INVALID
+  catch (const fenv_error &) {
     PyErr_SetString(PyExc_FloatingPointError,
                     "NaN dissimilarity value in intermediate results.");
     return NULL;
   }
-  #endif
-  catch(...){
-    PyErr_SetString(PyExc_EnvironmentError,
-                    "C++ exception (unknown reason). Please send a bug report.");
+#endif
+  catch (...) {
+    PyErr_SetString(
+        PyExc_EnvironmentError,
+        "C++ exception (unknown reason). Please send a bug report.");
     return NULL;
   }
 #if HAVE_DIAGNOSTIC
@@ -395,29 +451,29 @@ static PyObject *linkage_wrap(PyObject * const, PyObject * const args) {
 */
 enum metric_codes {
   // metrics
-  METRIC_EUCLIDEAN       =  0,
-  METRIC_MINKOWSKI       =  1,
-  METRIC_CITYBLOCK       =  2,
-  METRIC_SEUCLIDEAN      =  3,
-  METRIC_SQEUCLIDEAN     =  4,
-  METRIC_COSINE          =  5,
-  METRIC_HAMMING         =  6,
-  METRIC_JACCARD         =  7,
-  METRIC_CHEBYCHEV       =  8,
-  METRIC_CANBERRA        =  9,
-  METRIC_BRAYCURTIS      = 10,
-  METRIC_MAHALANOBIS     = 11,
-  METRIC_YULE            = 12,
-  METRIC_MATCHING        = 13,
-  METRIC_DICE            = 14,
-  METRIC_ROGERSTANIMOTO  = 15,
-  METRIC_RUSSELLRAO      = 16,
-  METRIC_SOKALSNEATH     = 17,
-  METRIC_KULSINSKI       = 18,
-  METRIC_USER            = 19,
-  METRIC_INVALID         = 20, // sentinel
-  METRIC_JACCARD_BOOL    = 21, // separate function for Jaccard metric on
-};                             // Boolean input data
+  METRIC_EUCLIDEAN = 0,
+  METRIC_MINKOWSKI = 1,
+  METRIC_CITYBLOCK = 2,
+  METRIC_SEUCLIDEAN = 3,
+  METRIC_SQEUCLIDEAN = 4,
+  METRIC_COSINE = 5,
+  METRIC_HAMMING = 6,
+  METRIC_JACCARD = 7,
+  METRIC_CHEBYCHEV = 8,
+  METRIC_CANBERRA = 9,
+  METRIC_BRAYCURTIS = 10,
+  METRIC_MAHALANOBIS = 11,
+  METRIC_YULE = 12,
+  METRIC_MATCHING = 13,
+  METRIC_DICE = 14,
+  METRIC_ROGERSTANIMOTO = 15,
+  METRIC_RUSSELLRAO = 16,
+  METRIC_SOKALSNEATH = 17,
+  METRIC_KULSINSKI = 18,
+  METRIC_USER = 19,
+  METRIC_INVALID = 20,      // sentinel
+  METRIC_JACCARD_BOOL = 21, // separate function for Jaccard metric on
+};                          // Boolean input data
 
 /*
    Helper class: Throw this if calling the Python interpreter from within
@@ -430,32 +486,32 @@ class pythonerror {};
   computation.
 */
 
-class python_dissimilarity {
+template <typename T> class python_dissimilarity {
 private:
-  t_float * Xa;
+  T *Xa;
   std::ptrdiff_t dim; // size_t saves many statis_cast<> in products
   t_index N;
-  auto_array_ptr<t_float> Xnew;
-  t_index * members;
-  void (cluster_result::*postprocessfn) (const t_float) const;
-  t_float postprocessarg;
+  auto_array_ptr<T> Xnew;
+  t_index *members;
+  void (cluster_result<T>::*postprocessfn)(const T) const;
+  T postprocessarg;
 
-  t_float (python_dissimilarity::*distfn) (const t_index, const t_index) const;
+  T (python_dissimilarity::*distfn)(const t_index, const t_index) const;
 
   // for user-defined metrics
-  PyObject * X_Python;
-  PyObject * userfn;
+  PyObject *X_Python;
+  PyObject *userfn;
 
-  auto_array_ptr<t_float> precomputed;
-  t_float * precomputed2;
+  auto_array_ptr<T> precomputed;
+  T *precomputed2;
 
-  PyArrayObject * V;
-  const t_float * V_data;
+  PyArrayObject *V;
+  const T *V_data;
 
   // noncopyable
   python_dissimilarity();
   python_dissimilarity(python_dissimilarity const &);
-  python_dissimilarity & operator=(python_dissimilarity const &);
+  python_dissimilarity &operator=(python_dissimilarity const &);
 
 public:
   // Ignore warning about uninitialized member variables. I know what I am
@@ -464,20 +520,24 @@ public:
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Weffc++"
 #endif
-  python_dissimilarity (PyArrayObject * const Xarg,
-                        t_index * const members_,
-                        const method_codes method,
-                        const metric_codes metric,
-                        PyObject * const extraarg,
-                        bool temp_point_array)
-    : Xa(reinterpret_cast<t_float *>(PyArray_DATA(Xarg))),
-      dim(PyArray_DIM(Xarg, 1)),
-      N(static_cast<t_index>(PyArray_DIM(Xarg, 0))),
-      Xnew(temp_point_array ? (N-1)*dim : 0),
-      members(members_),
-      postprocessfn(NULL),
-      V(NULL)
-  {
+  python_dissimilarity(PyArrayObject *const Xarg, t_index *const members_,
+                       const method_codes method, const metric_codes metric,
+                       PyObject *const extraarg, bool temp_point_array)
+      : Xa(reinterpret_cast<T *>(PyArray_DATA(Xarg))),
+        dim(PyArray_DIM(Xarg, 1)),
+        N(static_cast<t_index>(PyArray_DIM(Xarg, 0))),
+        Xnew(temp_point_array ? (N - 1) * dim : 0), members(members_),
+        postprocessfn(NULL), V(NULL) {
+    int numpyType;
+    if (typeid(T) == typeid(float)) {
+      numpyType = NPY_FLOAT;
+    } else if (typeid(T) == typeid(double)) {
+      numpyType = NPY_DOUBLE;
+    } else {
+      // Handle error or unsupported type, should be caught earlier
+      throw std::runtime_error(
+          "Unsupported data type.");
+    }
     switch (method) {
     case METHOD_METR_SINGLE:
       postprocessfn = NULL; // default
@@ -486,8 +546,9 @@ public:
         set_euclidean();
         break;
       case METRIC_SEUCLIDEAN:
-        if (extraarg==NULL) {
-          PyErr_SetString(PyExc_TypeError,
+        if (extraarg == NULL) {
+          PyErr_SetString(
+              PyExc_TypeError,
               "The 'seuclidean' metric needs a variance parameter.");
           throw pythonerror();
         }
@@ -495,25 +556,23 @@ public:
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif
-        V = reinterpret_cast<PyArrayObject *>(PyArray_FromAny(extraarg,
-                PyArray_DescrFromType(NPY_FLOAT),
-                1, 1,
-                NPY_ARRAY_CARRAY_RO,
-                NULL));
+        V = reinterpret_cast<PyArrayObject *>(
+            PyArray_FromAny(extraarg, PyArray_DescrFromType(numpyType), 1, 1,
+                            NPY_ARRAY_CARRAY_RO, NULL));
 #if HAVE_DIAGNOSTIC
 #pragma GCC diagnostic pop
 #endif
         if (PyErr_Occurred()) {
           throw pythonerror();
         }
-        if (PyArray_DIM(V, 0)!=dim) {
-          PyErr_SetString(PyExc_ValueError,
-          "The variance vector must have the same dimensionality as the data.");
+        if (PyArray_DIM(V, 0) != dim) {
+          PyErr_SetString(PyExc_ValueError, "The variance vector must have the "
+                                            "same dimensionality as the data.");
           throw pythonerror();
         }
-        V_data = reinterpret_cast<t_float *>(PyArray_DATA(V));
+        V_data = reinterpret_cast<T *>(PyArray_DATA(V));
         distfn = &python_dissimilarity::seuclidean;
-        postprocessfn = &cluster_result::sqrt;
+        postprocessfn = &cluster_result<T>::sqrt;
         break;
       case METRIC_SQEUCLIDEAN:
         distfn = &python_dissimilarity::sqeuclidean<false>;
@@ -529,21 +588,21 @@ public:
         break;
       case METRIC_COSINE:
         distfn = &python_dissimilarity::cosine;
-        postprocessfn = &cluster_result::plusone;
+        postprocessfn = &cluster_result<T>::plusone;
         // precompute norms
         precomputed.init(N);
-        for (t_index i=0; i<N; ++i) {
-          t_float sum=0;
-          for (t_index k=0; k<dim; ++k) {
-            sum += X(i,k)*X(i,k);
+        for (t_index i = 0; i < N; ++i) {
+          T sum = 0;
+          for (t_index k = 0; k < dim; ++k) {
+            sum += X(i, k) * X(i, k);
           }
-          precomputed[i] = 1/std::sqrt(sum);
+          precomputed[i] = 1 / std::sqrt(sum);
         }
         break;
       case METRIC_HAMMING:
         distfn = &python_dissimilarity::hamming;
-        postprocessfn = &cluster_result::divide;
-        postprocessarg = static_cast<t_float>(dim);
+        postprocessfn = &cluster_result<T>::divide;
+        postprocessarg = static_cast<T>(dim);
         break;
       case METRIC_JACCARD:
         distfn = &python_dissimilarity::jaccard;
@@ -555,42 +614,41 @@ public:
         distfn = &python_dissimilarity::braycurtis;
         break;
       case METRIC_MAHALANOBIS:
-        if (extraarg==NULL) {
+        if (extraarg == NULL) {
           PyErr_SetString(PyExc_TypeError,
-            "The 'mahalanobis' metric needs a parameter for the inverse covariance.");
+                          "The 'mahalanobis' metric needs a parameter for the "
+                          "inverse covariance.");
           throw pythonerror();
         }
 #if HAVE_DIAGNOSTIC
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif
-        V = reinterpret_cast<PyArrayObject *>(PyArray_FromAny(extraarg,
-              PyArray_DescrFromType(NPY_FLOAT),
-              2, 2,
-              NPY_ARRAY_CARRAY_RO,
-              NULL));
+        V = reinterpret_cast<PyArrayObject *>(
+            PyArray_FromAny(extraarg, PyArray_DescrFromType(numpyType), 2, 2,
+                            NPY_ARRAY_CARRAY_RO, NULL));
 #if HAVE_DIAGNOSTIC
 #pragma GCC diagnostic pop
 #endif
         if (PyErr_Occurred()) {
           throw pythonerror();
         }
-        if (PyArray_DIM(V, 0)!=N || PyArray_DIM(V, 1)!=dim) {
+        if (PyArray_DIM(V, 0) != N || PyArray_DIM(V, 1) != dim) {
           PyErr_SetString(PyExc_ValueError,
-            "The inverse covariance matrix has the wrong size.");
+                          "The inverse covariance matrix has the wrong size.");
           throw pythonerror();
         }
-        V_data = reinterpret_cast<t_float *>(PyArray_DATA(V));
+        V_data = reinterpret_cast<T *>(PyArray_DATA(V));
         distfn = &python_dissimilarity::mahalanobis;
-        postprocessfn = &cluster_result::sqrt;
+        postprocessfn = &cluster_result<T>::sqrt;
         break;
       case METRIC_YULE:
         distfn = &python_dissimilarity::yule;
         break;
       case METRIC_MATCHING:
         distfn = &python_dissimilarity::matching;
-        postprocessfn = &cluster_result::divide;
-        postprocessarg = static_cast<t_float>(dim);
+        postprocessfn = &cluster_result<T>::divide;
+        postprocessarg = static_cast<T>(dim);
         break;
       case METRIC_DICE:
         distfn = &python_dissimilarity::dice;
@@ -600,22 +658,22 @@ public:
         break;
       case METRIC_RUSSELLRAO:
         distfn = &python_dissimilarity::russellrao;
-        postprocessfn = &cluster_result::divide;
-        postprocessarg = static_cast<t_float>(dim);
+        postprocessfn = &cluster_result<T>::divide;
+        postprocessarg = static_cast<T>(dim);
         break;
       case METRIC_SOKALSNEATH:
         distfn = &python_dissimilarity::sokalsneath;
         break;
       case METRIC_KULSINSKI:
         distfn = &python_dissimilarity::kulsinski;
-        postprocessfn = &cluster_result::plusone;
+        postprocessfn = &cluster_result<T>::plusone;
         precomputed.init(N);
-        for (t_index i=0; i<N; ++i) {
-          t_index sum=0;
-          for (t_index k=0; k<dim; ++k) {
-            sum += Xb(i,k);
+        for (t_index i = 0; i < N; ++i) {
+          t_index sum = 0;
+          for (t_index k = 0; k < dim; ++k) {
+            sum += Xb(i, k);
           }
-          precomputed[i] = -.5/static_cast<t_float>(sum);
+          precomputed[i] = -.5 / static_cast<T>(sum);
         }
         break;
       case METRIC_USER:
@@ -629,11 +687,11 @@ public:
       break;
 
     case METHOD_METR_WARD:
-      postprocessfn = &cluster_result::sqrtdouble;
+      postprocessfn = &cluster_result<T>::sqrtdouble;
       break;
 
     default:
-      postprocessfn = &cluster_result::sqrt;
+      postprocessfn = &cluster_result<T>::sqrt;
     }
   }
 #if HAVE_DIAGNOSTIC
@@ -651,88 +709,84 @@ public:
 #endif
   }
 
-  inline t_float operator () (const t_index i, const t_index j) const {
-    return (this->*distfn)(i,j);
+  inline T operator()(const t_index i, const t_index j) const {
+    return (this->*distfn)(i, j);
   }
 
-  inline t_float X (const t_index i, const t_index j) const {
-    return Xa[i*dim+j];
+  inline T X(const t_index i, const t_index j) const { return Xa[i * dim + j]; }
+
+  inline bool Xb(const t_index i, const t_index j) const {
+    return reinterpret_cast<bool *>(Xa)[i * dim + j];
   }
 
-  inline bool Xb (const t_index i, const t_index j) const {
-    return  reinterpret_cast<bool *>(Xa)[i*dim+j];
-  }
-
-  inline t_float * Xptr(const t_index i, const t_index j) const {
-    return Xa+i*dim+j;
+  inline T *Xptr(const t_index i, const t_index j) const {
+    return Xa + i * dim + j;
   }
 
   void merge(const t_index i, const t_index j, const t_index newnode) const {
-    t_float const * const Pi = i<N ? Xa+i*dim : Xnew+(i-N)*dim;
-    t_float const * const Pj = j<N ? Xa+j*dim : Xnew+(j-N)*dim;
-    for(t_index k=0; k<dim; ++k) {
-      Xnew[(newnode-N)*dim+k] = (Pi[k]*static_cast<t_float>(members[i]) +
-                                 Pj[k]*static_cast<t_float>(members[j])) /
-        static_cast<t_float>(members[i]+members[j]);
+    T const *const Pi = i < N ? Xa + i * dim : Xnew + (i - N) * dim;
+    T const *const Pj = j < N ? Xa + j * dim : Xnew + (j - N) * dim;
+    for (t_index k = 0; k < dim; ++k) {
+      Xnew[(newnode - N) * dim + k] = (Pi[k] * static_cast<T>(members[i]) +
+                                       Pj[k] * static_cast<T>(members[j])) /
+                                      static_cast<T>(members[i] + members[j]);
     }
-    members[newnode] = members[i]+members[j];
+    members[newnode] = members[i] + members[j];
   }
 
-  void merge_weighted(const t_index i, const t_index j, const t_index newnode)
-    const {
-    t_float const * const Pi = i<N ? Xa+i*dim : Xnew+(i-N)*dim;
-    t_float const * const Pj = j<N ? Xa+j*dim : Xnew+(j-N)*dim;
-    for(t_index k=0; k<dim; ++k) {
-      Xnew[(newnode-N)*dim+k] = (Pi[k]+Pj[k])*.5;
+  void merge_weighted(const t_index i, const t_index j,
+                      const t_index newnode) const {
+    T const *const Pi = i < N ? Xa + i * dim : Xnew + (i - N) * dim;
+    T const *const Pj = j < N ? Xa + j * dim : Xnew + (j - N) * dim;
+    for (t_index k = 0; k < dim; ++k) {
+      Xnew[(newnode - N) * dim + k] = (Pi[k] + Pj[k]) * .5;
     }
   }
 
   void merge_inplace(const t_index i, const t_index j) const {
-    t_float const * const Pi = Xa+i*dim;
-    t_float * const Pj = Xa+j*dim;
-    for(t_index k=0; k<dim; ++k) {
-      Pj[k] = (Pi[k]*static_cast<t_float>(members[i]) +
-               Pj[k]*static_cast<t_float>(members[j])) /
-        static_cast<t_float>(members[i]+members[j]);
+    T const *const Pi = Xa + i * dim;
+    T *const Pj = Xa + j * dim;
+    for (t_index k = 0; k < dim; ++k) {
+      Pj[k] = (Pi[k] * static_cast<T>(members[i]) +
+               Pj[k] * static_cast<T>(members[j])) /
+              static_cast<T>(members[i] + members[j]);
     }
     members[j] += members[i];
   }
 
   void merge_inplace_weighted(const t_index i, const t_index j) const {
-    t_float const * const Pi = Xa+i*dim;
-    t_float * const Pj = Xa+j*dim;
-    for(t_index k=0; k<dim; ++k) {
-      Pj[k] = (Pi[k]+Pj[k])*.5;
+    T const *const Pi = Xa + i * dim;
+    T *const Pj = Xa + j * dim;
+    for (t_index k = 0; k < dim; ++k) {
+      Pj[k] = (Pi[k] + Pj[k]) * .5;
     }
   }
 
-  void postprocess(cluster_result & Z2) const {
-    if (postprocessfn!=NULL) {
-        (Z2.*postprocessfn)(postprocessarg);
+  void postprocess(cluster_result<T> &Z2) const {
+    if (postprocessfn != NULL) {
+      (Z2.*postprocessfn)(postprocessarg);
     }
   }
 
-  inline t_float ward(const t_index i, const t_index j) const {
-    t_float mi = static_cast<t_float>(members[i]);
-    t_float mj = static_cast<t_float>(members[j]);
-    return sqeuclidean<true>(i,j)*mi*mj/(mi+mj);
+  inline T ward(const t_index i, const t_index j) const {
+    T mi = static_cast<T>(members[i]);
+    T mj = static_cast<T>(members[j]);
+    return sqeuclidean<true>(i, j) * mi * mj / (mi + mj);
   }
 
-  inline t_float ward_initial(const t_index i, const t_index j) const {
+  inline T ward_initial(const t_index i, const t_index j) const {
     // alias for sqeuclidean
     // Factor 2!!!
-    return sqeuclidean<true>(i,j);
+    return sqeuclidean<true>(i, j);
   }
 
   // This method must not produce NaN if the input is non-NaN.
-  inline static t_float ward_initial_conversion(const t_float min) {
-    return min*.5;
-  }
+  inline static T ward_initial_conversion(const T min) { return min * .5; }
 
-  inline t_float ward_extended(const t_index i, const t_index j) const {
-    t_float mi = static_cast<t_float>(members[i]);
-    t_float mj = static_cast<t_float>(members[j]);
-    return sqeuclidean_extended(i,j)*mi*mj/(mi+mj);
+  inline T ward_extended(const t_index i, const t_index j) const {
+    T mi = static_cast<T>(members[i]);
+    T mj = static_cast<T>(members[j]);
+    return sqeuclidean_extended(i, j) * mi * mj / (mi + mj);
   }
 
   /* We need two variants of the Euclidean metric: one that does not check
@@ -740,20 +794,20 @@ public:
      does, for the updated distances during the clustering procedure.
   */
   template <const bool check_NaN>
-  t_float sqeuclidean(const t_index i, const t_index j) const {
-    t_float sum = 0;
+  T sqeuclidean(const t_index i, const t_index j) const {
+    T sum = 0;
     /*
       for (t_index k=0; k<dim; ++k) {
-      t_float diff = X(i,k) - X(j,k);
+      T diff = X(i,k) - X(j,k);
       sum += diff*diff;
       }
     */
     // faster
-    t_float const * Pi = Xa+i*dim;
-    t_float const * Pj = Xa+j*dim;
-    for (t_index k=0; k<dim; ++k) {
-      t_float diff = Pi[k] - Pj[k];
-      sum += diff*diff;
+    T const *Pi = Xa + i * dim;
+    T const *Pj = Xa + j * dim;
+    for (t_index k = 0; k < dim; ++k) {
+      T diff = Pi[k] - Pj[k];
+      sum += diff * diff;
     }
     if (check_NaN) {
 #if HAVE_DIAGNOSTIC
@@ -769,13 +823,13 @@ public:
     return sum;
   }
 
-  t_float sqeuclidean_extended(const t_index i, const t_index j) const {
-    t_float sum = 0;
-    t_float const * Pi = i<N ? Xa+i*dim : Xnew+(i-N)*dim; // TBD
-    t_float const * Pj = j<N ? Xa+j*dim : Xnew+(j-N)*dim;
-    for (t_index k=0; k<dim; ++k) {
-      t_float diff = Pi[k] - Pj[k];
-      sum += diff*diff;
+  T sqeuclidean_extended(const t_index i, const t_index j) const {
+    T sum = 0;
+    T const *Pi = i < N ? Xa + i * dim : Xnew + (i - N) * dim; // TBD
+    T const *Pj = j < N ? Xa + j * dim : Xnew + (j - N) * dim;
+    for (t_index k = 0; k < dim; ++k) {
+      T diff = Pi[k] - Pj[k];
+      sum += diff * diff;
     }
 #if HAVE_DIAGNOSTIC
 #pragma GCC diagnostic push
@@ -790,13 +844,13 @@ public:
   }
 
 private:
-  void set_minkowski(PyObject * extraarg) {
-    if (extraarg==NULL) {
+  void set_minkowski(PyObject *extraarg) {
+    if (extraarg == NULL) {
       PyErr_SetString(PyExc_TypeError,
                       "The Minkowski metric needs a parameter.");
       throw pythonerror();
     }
-    postprocessarg = static_cast<t_float>(PyFloat_AsDouble(extraarg));
+    postprocessarg = static_cast<T>(PyFloat_AsDouble(extraarg));
     if (PyErr_Occurred()) {
       throw pythonerror();
     }
@@ -805,18 +859,15 @@ private:
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wfloat-equal"
 #endif
-    if (postprocessarg==std::numeric_limits<t_float>::infinity()) {
+    if (postprocessarg == std::numeric_limits<T>::infinity()) {
       set_chebychev();
-    }
-    else if (postprocessarg==1.0){
+    } else if (postprocessarg == 1.0) {
       set_cityblock();
-    }
-    else if (postprocessarg==2.0){
+    } else if (postprocessarg == 2.0) {
       set_euclidean();
-    }
-    else {
+    } else {
       distfn = &python_dissimilarity::minkowski;
-      postprocessfn = &cluster_result::power;
+      postprocessfn = &cluster_result<T>::power;
     }
 #if HAVE_DIAGNOSTIC
 #pragma GCC diagnostic pop
@@ -825,69 +876,65 @@ private:
 
   void set_euclidean() {
     distfn = &python_dissimilarity::sqeuclidean<false>;
-    postprocessfn = &cluster_result::sqrt;
+    postprocessfn = &cluster_result<T>::sqrt;
   }
 
-  void set_cityblock() {
-    distfn = &python_dissimilarity::cityblock;
-  }
+  void set_cityblock() { distfn = &python_dissimilarity::cityblock; }
 
-  void set_chebychev() {
-    distfn = &python_dissimilarity::chebychev;
-  }
+  void set_chebychev() { distfn = &python_dissimilarity::chebychev; }
 
-  t_float seuclidean(const t_index i, const t_index j) const {
-    t_float sum = 0;
-    for (t_index k=0; k<dim; ++k) {
-      t_float diff = X(i,k)-X(j,k);
-      sum += diff*diff/V_data[k];
+  T seuclidean(const t_index i, const t_index j) const {
+    T sum = 0;
+    for (t_index k = 0; k < dim; ++k) {
+      T diff = X(i, k) - X(j, k);
+      sum += diff * diff / V_data[k];
     }
     return sum;
   }
 
-  t_float cityblock(const t_index i, const t_index j) const {
-    t_float sum = 0;
-    for (t_index k=0; k<dim; ++k) {
-      sum += std::abs(X(i,k)-X(j,k));
+  T cityblock(const t_index i, const t_index j) const {
+    T sum = 0;
+    for (t_index k = 0; k < dim; ++k) {
+      sum += std::abs(X(i, k) - X(j, k));
     }
     return sum;
   }
 
-  t_float minkowski(const t_index i, const t_index j) const {
-    t_float sum = 0;
-    for (t_index k=0; k<dim; ++k) {
-      sum += std::pow(std::abs(X(i,k)-X(j,k)),postprocessarg);
+  T minkowski(const t_index i, const t_index j) const {
+    T sum = 0;
+    for (t_index k = 0; k < dim; ++k) {
+      sum += std::pow(std::abs(X(i, k) - X(j, k)), postprocessarg);
     }
     return sum;
   }
 
-  t_float chebychev(const t_index i, const t_index j) const {
-    t_float max = 0;
-    for (t_index k=0; k<dim; ++k) {
-      t_float diff = std::abs(X(i,k)-X(j,k));
-      if (diff>max) {
+  T chebychev(const t_index i, const t_index j) const {
+    T max = 0;
+    for (t_index k = 0; k < dim; ++k) {
+      T diff = std::abs(X(i, k) - X(j, k));
+      if (diff > max) {
         max = diff;
       }
     }
     return max;
   }
 
-  t_float cosine(const t_index i, const t_index j) const {
-    t_float sum = 0;
-    for (t_index k=0; k<dim; ++k) {
-      sum -= X(i,k)*X(j,k);
+  T cosine(const t_index i, const t_index j) const {
+    T sum = 0;
+    for (t_index k = 0; k < dim; ++k) {
+      sum -= X(i, k) * X(j, k);
     }
-    return sum*precomputed[i]*precomputed[j];
+    return sum * precomputed[i] * precomputed[j];
   }
 
-  t_float hamming(const t_index i, const t_index j) const {
-    t_float sum = 0;
-    for (t_index k=0; k<dim; ++k) {
+  T hamming(const t_index i, const t_index j) const {
+    T sum = 0;
+    for (t_index k = 0; k < dim; ++k) {
 #if HAVE_DIAGNOSTIC
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wfloat-equal"
 #endif
-      sum += (X(i,k)!=X(j,k));
+      sum += (X(i, k) != X(j, k));
 #if HAVE_DIAGNOSTIC
 #pragma GCC diagnostic pop
 #endif
@@ -897,32 +944,34 @@ private:
 
   // Differs from scipy.spatial.distance: equal vectors correctly
   // return distance 0.
-  t_float jaccard(const t_index i, const t_index j) const {
+  T jaccard(const t_index i, const t_index j) const {
     t_index sum1 = 0;
     t_index sum2 = 0;
-    for (t_index k=0; k<dim; ++k) {
+    for (t_index k = 0; k < dim; ++k) {
 #if HAVE_DIAGNOSTIC
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wfloat-equal"
 #endif
-      sum1 += (X(i,k)!=X(j,k));
-      sum2 += ((X(i,k)!=0) || (X(j,k)!=0));
+      sum1 += (X(i, k) != X(j, k));
+      sum2 += ((X(i, k) != 0) || (X(j, k) != 0));
 #if HAVE_DIAGNOSTIC
 #pragma GCC diagnostic pop
 #endif
     }
-    return sum1==0 ? 0 : static_cast<t_float>(sum1) / static_cast<t_float>(sum2);
+    return sum1 == 0 ? 0 : static_cast<T>(sum1) / static_cast<T>(sum2);
   }
 
-  t_float canberra(const t_index i, const t_index j) const {
-    t_float sum = 0;
-    for (t_index k=0; k<dim; ++k) {
-      t_float numerator = std::abs(X(i,k)-X(j,k));
+  T canberra(const t_index i, const t_index j) const {
+    T sum = 0;
+    for (t_index k = 0; k < dim; ++k) {
+      T numerator = std::abs(X(i, k) - X(j, k));
 #if HAVE_DIAGNOSTIC
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wfloat-equal"
 #endif
-      sum += numerator==0 ? 0 : numerator / (std::abs(X(i,k)) + std::abs(X(j,k)));
+      sum += numerator == 0
+                 ? 0
+                 : numerator / (std::abs(X(i, k)) + std::abs(X(j, k)));
 #if HAVE_DIAGNOSTIC
 #pragma GCC diagnostic pop
 #endif
@@ -930,27 +979,27 @@ private:
     return sum;
   }
 
-  t_float user(const t_index i, const t_index j) const {
+  T user(const t_index i, const t_index j) const {
 #if HAVE_DIAGNOSTIC
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif
-    PyObject * u = PySequence_ITEM(X_Python, i);
-    PyObject * v = PySequence_ITEM(X_Python, j);
-    PyObject * result = PyObject_CallFunctionObjArgs(userfn, u, v, NULL);
+    PyObject *u = PySequence_ITEM(X_Python, i);
+    PyObject *v = PySequence_ITEM(X_Python, j);
+    PyObject *result = PyObject_CallFunctionObjArgs(userfn, u, v, NULL);
     Py_DECREF(u);
     Py_DECREF(v);
 #if HAVE_DIAGNOSTIC
 #pragma GCC diagnostic pop
 #endif
-    if (result==NULL) {
+    if (result == NULL) {
       throw pythonerror();
     }
 #if HAVE_DIAGNOSTIC
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif
-    const t_float C_result = static_cast<t_float>(PyFloat_AsDouble(result));
+    const T C_result = PyFloat_AsDouble(result);
     Py_DECREF(result);
 #if HAVE_DIAGNOSTIC
 #pragma GCC diagnostic pop
@@ -961,21 +1010,21 @@ private:
     return C_result;
   }
 
-  t_float braycurtis(const t_index i, const t_index j) const {
-    t_float sum1 = 0;
-    t_float sum2 = 0;
-    for (t_index k=0; k<dim; ++k) {
-      sum1 += std::abs(X(i,k)-X(j,k));
-      sum2 += std::abs(X(i,k)+X(j,k));
+  T braycurtis(const t_index i, const t_index j) const {
+    T sum1 = 0;
+    T sum2 = 0;
+    for (t_index k = 0; k < dim; ++k) {
+      sum1 += std::abs(X(i, k) - X(j, k));
+      sum2 += std::abs(X(i, k) + X(j, k));
     }
-    return sum1/sum2;
+    return sum1 / sum2;
   }
 
-  t_float mahalanobis(const t_index i, const t_index j) const {
+  T mahalanobis(const t_index i, const t_index j) const {
     // V_data contains the product X*VI
-    t_float sum = 0;
-    for (t_index k=0; k<dim; ++k) {
-      sum += (V_data[i*dim+k]-V_data[j*dim+k])*(X(i,k)-X(j,k));
+    T sum = 0;
+    for (t_index k = 0; k < dim; ++k) {
+      sum += (V_data[i * dim + k] - V_data[j * dim + k]) * (X(i, k) - X(j, k));
     }
     return sum;
   }
@@ -983,15 +1032,15 @@ private:
   t_index mutable NTT; // 'local' variables
   t_index mutable NXO;
   t_index mutable NTF;
-  #define NTFFT NTF
-  #define NFFTT NTT
+#define NTFFT NTF
+#define NFFTT NTT
 
   void nbool_correspond(const t_index i, const t_index j) const {
     NTT = 0;
     NXO = 0;
-    for (t_index k=0; k<dim; ++k) {
-      NTT += (Xb(i,k) &  Xb(j,k)) ;
-      NXO += (Xb(i,k) ^  Xb(j,k)) ;
+    for (t_index k = 0; k < dim; ++k) {
+      NTT += (Xb(i, k) & Xb(j, k));
+      NXO += (Xb(i, k) ^ Xb(j, k));
     }
   }
 
@@ -999,107 +1048,110 @@ private:
     NTT = 0;
     NXO = 0;
     NTF = 0;
-    for (t_index k=0; k<dim; ++k) {
-      NTT += (Xb(i,k) &  Xb(j,k)) ;
-      NXO += (Xb(i,k) ^  Xb(j,k)) ;
-      NTF += (Xb(i,k) & !Xb(j,k)) ;
+    for (t_index k = 0; k < dim; ++k) {
+      NTT += (Xb(i, k) & Xb(j, k));
+      NXO += (Xb(i, k) ^ Xb(j, k));
+      NTF += (Xb(i, k) & !Xb(j, k));
     }
-    NTF *= (NXO-NTF); // NTFFT
-    NTT *= (static_cast<t_index>(dim)-NTT-NXO); // NFFTT
+    NTF *= (NXO - NTF);                             // NTFFT
+    NTT *= (static_cast<t_index>(dim) - NTT - NXO); // NFFTT
   }
 
   void nbool_correspond_xo(const t_index i, const t_index j) const {
     NXO = 0;
-    for (t_index k=0; k<dim; ++k) {
-      NXO += (Xb(i,k) ^ Xb(j,k)) ;
+    for (t_index k = 0; k < dim; ++k) {
+      NXO += (Xb(i, k) ^ Xb(j, k));
     }
   }
 
   void nbool_correspond_tt(const t_index i, const t_index j) const {
     NTT = 0;
-    for (t_index k=0; k<dim; ++k) {
-      NTT += (Xb(i,k) & Xb(j,k)) ;
+    for (t_index k = 0; k < dim; ++k) {
+      NTT += (Xb(i, k) & Xb(j, k));
     }
   }
 
-  t_float yule(const t_index i, const t_index j) const {
+  T yule(const t_index i, const t_index j) const {
     nbool_correspond_tfft(i, j);
-    return (NTFFT==0) ? 0 :
-      static_cast<t_float>(2*NTFFT) / static_cast<t_float>(NTFFT + NFFTT);
+    return (NTFFT == 0)
+               ? 0
+               : static_cast<T>(2 * NTFFT) / static_cast<T>(NTFFT + NFFTT);
   }
 
   // Prevent a zero denominator for equal vectors.
-  t_float dice(const t_index i, const t_index j) const {
+  T dice(const t_index i, const t_index j) const {
     nbool_correspond(i, j);
-    return (NXO==0) ? 0 :
-      static_cast<t_float>(NXO) / static_cast<t_float>(NXO+2*NTT);
+    return (NXO == 0) ? 0 : static_cast<T>(NXO) / static_cast<T>(NXO + 2 * NTT);
   }
 
-  t_float rogerstanimoto(const t_index i, const t_index j) const {
+  T rogerstanimoto(const t_index i, const t_index j) const {
     nbool_correspond_xo(i, j);
-    return static_cast<t_float>(2*NXO) / static_cast<t_float>(NXO+dim);
+    return static_cast<T>(2 * NXO) / static_cast<T>(NXO + dim);
   }
 
-  t_float russellrao(const t_index i, const t_index j) const {
+  T russellrao(const t_index i, const t_index j) const {
     nbool_correspond_tt(i, j);
-    return static_cast<t_float>(dim-NTT);
+    return static_cast<T>(dim - NTT);
   }
 
   // Prevent a zero denominator for equal vectors.
-  t_float sokalsneath(const t_index i, const t_index j) const {
+  T sokalsneath(const t_index i, const t_index j) const {
     nbool_correspond(i, j);
-    return (NXO==0) ? 0 :
-      static_cast<t_float>(2*NXO) / static_cast<t_float>(NTT+2*NXO);
+    return (NXO == 0) ? 0
+                      : static_cast<T>(2 * NXO) / static_cast<T>(NTT + 2 * NXO);
   }
 
-  t_float kulsinski(const t_index i, const t_index j) const {
+  T kulsinski(const t_index i, const t_index j) const {
     nbool_correspond_tt(i, j);
-    return static_cast<t_float>(NTT) * (precomputed[i] + precomputed[j]);
+    return static_cast<T>(NTT) * (precomputed[i] + precomputed[j]);
   }
 
   // 'matching' distance = Hamming distance
-  t_float matching(const t_index i, const t_index j) const {
+  T matching(const t_index i, const t_index j) const {
     nbool_correspond_xo(i, j);
-    return static_cast<t_float>(NXO);
+    return static_cast<T>(NXO);
   }
 
   // Prevent a zero denominator for equal vectors.
-  t_float jaccard_bool(const t_index i, const t_index j) const {
+  T jaccard_bool(const t_index i, const t_index j) const {
     nbool_correspond(i, j);
-    return (NXO==0) ? 0 :
-      static_cast<t_float>(NXO) / static_cast<t_float>(NXO+NTT);
+    return (NXO == 0) ? 0 : static_cast<T>(NXO) / static_cast<T>(NXO + NTT);
   }
 };
 
-static PyObject *linkage_vector_wrap(PyObject * const, PyObject * const args) {
-  PyArrayObject * X, * Z;
+static PyObject *linkage_vector_wrap(PyObject *const, PyObject *const args) {
+  PyArrayObject *X, *Z;
   unsigned char method, metric;
-  PyObject * extraarg;
+  PyObject *extraarg;
+  int high_precision_flag = 0;
 
-  try{
+  try {
     // Parse the input arguments
 #if HAVE_DIAGNOSTIC
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif
-    if (!PyArg_ParseTuple(args, "O!O!bbO",
-                          &PyArray_Type, &X, // NumPy array
-                          &PyArray_Type, &Z, // NumPy array
-                          &method,           // unsigned char
-                          &metric,           // unsigned char
-                          &extraarg )) {     // Python object
+    if (!PyArg_ParseTuple(args, "O!O!bbOp", &PyArray_Type, &X, // NumPy array
+                          &PyArray_Type, &Z,                   // NumPy array
+                          &method,                             // unsigned char
+                          &metric,                             // unsigned char
+                          &extraarg,                           // PyObject
+                          &high_precision_flag)) {             // int
       return NULL;
     }
 #if HAVE_DIAGNOSTIC
 #pragma GCC diagnostic pop
 #endif
 
+    bool high_precision = high_precision_flag != 0;
+    int T_mant_dig = high_precision ? DBL_MANT_DIG : FLT_MANT_DIG;
+
     if (PyArray_NDIM(X) != 2) {
       PyErr_SetString(PyExc_ValueError,
                       "The input array must be two-dimensional.");
     }
     npy_intp const N_ = PyArray_DIM(X, 0);
-    if (N_ < 1 ) {
+    if (N_ < 1) {
       // N must be at least 1.
       PyErr_SetString(PyExc_ValueError,
                       "At least one element is needed for clustering.");
@@ -1107,9 +1159,8 @@ static PyObject *linkage_vector_wrap(PyObject * const, PyObject * const args) {
     }
 
     npy_intp const dim = PyArray_DIM(X, 1);
-    if (dim < 1 ) {
-      PyErr_SetString(PyExc_ValueError,
-                      "Invalid dimension of the data set.");
+    if (dim < 1) {
+      PyErr_SetString(PyExc_ValueError, "Invalid dimension of the data set.");
       return NULL;
     }
 
@@ -1127,112 +1178,181 @@ static PyObject *linkage_vector_wrap(PyObject * const, PyObject * const args) {
       a warning ("shift count >= width of type") on systems where "int" is 32
       bits wide.
     */
-    if (N_ > MAX_INDEX/4 || dim > MAX_INDEX ||
-        static_cast<int64_t>(N_-1)>>(T_FLOAT_MANT_DIG-1) > 0) {
-      PyErr_SetString(PyExc_ValueError,
-                      "Data is too big, index overflow.");
+    if (N_ > MAX_INDEX / 4 || dim > MAX_INDEX ||
+        static_cast<int64_t>(N_ - 1) >> (T_mant_dig - 1) > 0) {
+      PyErr_SetString(PyExc_ValueError, "Data is too big, index overflow.");
       return NULL;
     }
     t_index N = static_cast<t_index>(N_);
 
-    cluster_result Z2(N-1);
+    if (high_precision) {
+      using T = double;
+      cluster_result<T> Z2(N - 1);
 
-    auto_array_ptr<t_index> members;
-    if (method==METHOD_METR_WARD || method==METHOD_METR_CENTROID) {
-      members.init(2*N-1, 1);
-    }
-
-    if ((method!=METHOD_METR_SINGLE && metric!=METRIC_EUCLIDEAN) ||
-        metric>=METRIC_INVALID) {
-      PyErr_SetString(PyExc_IndexError, "Invalid metric index.");
-      return NULL;
-    }
-
-    if (PyArray_ISBOOL(X)) {
-      if (metric==METRIC_HAMMING) {
-        metric = METRIC_MATCHING; // Alias
+      auto_array_ptr<t_index> members;
+      if (method == METHOD_METR_WARD || method == METHOD_METR_CENTROID) {
+        members.init(2 * N - 1, 1);
       }
-      if (metric==METRIC_JACCARD) {
-        metric = METRIC_JACCARD_BOOL;
+
+      if ((method != METHOD_METR_SINGLE && metric != METRIC_EUCLIDEAN) ||
+          metric >= METRIC_INVALID) {
+        PyErr_SetString(PyExc_IndexError, "Invalid metric index.");
+        return NULL;
       }
-    }
 
-    if (extraarg!=Py_None &&
-        metric!=METRIC_MINKOWSKI &&
-        metric!=METRIC_SEUCLIDEAN &&
-        metric!=METRIC_MAHALANOBIS &&
-        metric!=METRIC_USER) {
-      PyErr_SetString(PyExc_TypeError,
-                      "No extra parameter is allowed for this metric.");
-      return NULL;
-    }
+      if (PyArray_ISBOOL(X)) {
+        if (metric == METRIC_HAMMING) {
+          metric = METRIC_MATCHING; // Alias
+        }
+        if (metric == METRIC_JACCARD) {
+          metric = METRIC_JACCARD_BOOL;
+        }
+      }
 
-    /* temp_point_array must be true if the alternative algorithm
-       is used below (currently for the centroid and median methods). */
-    bool temp_point_array = (method==METHOD_METR_CENTROID ||
-                             method==METHOD_METR_MEDIAN);
+      if (extraarg != Py_None && metric != METRIC_MINKOWSKI &&
+          metric != METRIC_SEUCLIDEAN && metric != METRIC_MAHALANOBIS &&
+          metric != METRIC_USER) {
+        PyErr_SetString(PyExc_TypeError,
+                        "No extra parameter is allowed for this metric.");
+        return NULL;
+      }
 
-    python_dissimilarity dist(X, members, static_cast<method_codes>(method),
-                              static_cast<metric_codes>(metric), extraarg,
-                              temp_point_array);
+      /* temp_point_array must be true if the alternative algorithm
+         is used below (currently for the centroid and median methods). */
+      bool temp_point_array =
+          (method == METHOD_METR_CENTROID || method == METHOD_METR_MEDIAN);
 
-    if (method!=METHOD_METR_SINGLE &&
-        method!=METHOD_METR_WARD &&
-        method!=METHOD_METR_CENTROID &&
-        method!=METHOD_METR_MEDIAN) {
-      PyErr_SetString(PyExc_IndexError, "Invalid method index.");
-      return NULL;
-    }
+      python_dissimilarity<T> dist(
+          X, members, static_cast<method_codes>(method),
+          static_cast<metric_codes>(metric), extraarg, temp_point_array);
 
-    // Allow threads if the metric is not "user"!
-    GIL_release G(metric!=METRIC_USER);
+      if (method != METHOD_METR_SINGLE && method != METHOD_METR_WARD &&
+          method != METHOD_METR_CENTROID && method != METHOD_METR_MEDIAN) {
+        PyErr_SetString(PyExc_IndexError, "Invalid method index.");
+        return NULL;
+      }
 
-    switch (method) {
-    case METHOD_METR_SINGLE:
-      MST_linkage_core_vector(N, dist, Z2);
-      break;
-    case METHOD_METR_WARD:
-      generic_linkage_vector<METHOD_VECTOR_WARD>(N, dist, Z2);
-      break;
-    case METHOD_METR_CENTROID:
-      generic_linkage_vector_alternative<METHOD_VECTOR_CENTROID>(N, dist, Z2);
-      break;
-    default: // case METHOD_METR_MEDIAN:
-      generic_linkage_vector_alternative<METHOD_VECTOR_MEDIAN>(N, dist, Z2);
-    }
+      // Allow threads if the metric is not "user"!
+      GIL_release G(metric != METRIC_USER);
 
-    if (method==METHOD_METR_WARD ||
-        method==METHOD_METR_CENTROID) {
-      members.free();
-    }
+      switch (method) {
+      case METHOD_METR_SINGLE:
+        MST_linkage_core_vector<T>(N, dist, Z2);
+        break;
+      case METHOD_METR_WARD:
+        generic_linkage_vector<METHOD_VECTOR_WARD, T>(N, dist, Z2);
+        break;
+      case METHOD_METR_CENTROID:
+        generic_linkage_vector_alternative<METHOD_VECTOR_CENTROID, T>(N, dist, Z2);
+        break;
+      default: // case METHOD_METR_MEDIAN:
+        generic_linkage_vector_alternative<METHOD_VECTOR_MEDIAN, T>(N, dist, Z2);
+      }
 
-    dist.postprocess(Z2);
+      if (method == METHOD_METR_WARD || method == METHOD_METR_CENTROID) {
+        members.free();
+      }
 
-    t_float * const Z_ = reinterpret_cast<t_float *>(PyArray_DATA(Z));
-    if (method!=METHOD_METR_SINGLE) {
-      generate_SciPy_dendrogram<true>(Z_, Z2, N);
-    }
-    else {
-      generate_SciPy_dendrogram<false>(Z_, Z2, N);
+      dist.postprocess(Z2);
+
+      T *const Z_ = reinterpret_cast<T *>(PyArray_DATA(Z));
+      if (method != METHOD_METR_SINGLE) {
+        generate_SciPy_dendrogram<true, T>(Z_, Z2, N);
+      } else {
+        generate_SciPy_dendrogram<false, T>(Z_, Z2, N);
+      }
+    } else {
+      using T = float;
+      cluster_result<T> Z2(N - 1);
+
+      auto_array_ptr<t_index> members;
+      if (method == METHOD_METR_WARD || method == METHOD_METR_CENTROID) {
+        members.init(2 * N - 1, 1);
+      }
+
+      if ((method != METHOD_METR_SINGLE && metric != METRIC_EUCLIDEAN) ||
+          metric >= METRIC_INVALID) {
+        PyErr_SetString(PyExc_IndexError, "Invalid metric index.");
+        return NULL;
+      }
+
+      if (PyArray_ISBOOL(X)) {
+        if (metric == METRIC_HAMMING) {
+          metric = METRIC_MATCHING; // Alias
+        }
+        if (metric == METRIC_JACCARD) {
+          metric = METRIC_JACCARD_BOOL;
+        }
+      }
+
+      if (extraarg != Py_None && metric != METRIC_MINKOWSKI &&
+          metric != METRIC_SEUCLIDEAN && metric != METRIC_MAHALANOBIS &&
+          metric != METRIC_USER) {
+        PyErr_SetString(PyExc_TypeError,
+                        "No extra parameter is allowed for this metric.");
+        return NULL;
+      }
+
+      /* temp_point_array must be true if the alternative algorithm
+         is used below (currently for the centroid and median methods). */
+      bool temp_point_array =
+          (method == METHOD_METR_CENTROID || method == METHOD_METR_MEDIAN);
+
+      python_dissimilarity<T> dist(
+          X, members, static_cast<method_codes>(method),
+          static_cast<metric_codes>(metric), extraarg, temp_point_array);
+
+      if (method != METHOD_METR_SINGLE && method != METHOD_METR_WARD &&
+          method != METHOD_METR_CENTROID && method != METHOD_METR_MEDIAN) {
+        PyErr_SetString(PyExc_IndexError, "Invalid method index.");
+        return NULL;
+      }
+
+      // Allow threads if the metric is not "user"!
+      GIL_release G(metric != METRIC_USER);
+
+      switch (method) {
+      case METHOD_METR_SINGLE:
+        MST_linkage_core_vector<T>(N, dist, Z2);
+        break;
+      case METHOD_METR_WARD:
+        generic_linkage_vector<METHOD_VECTOR_WARD, T>(N, dist, Z2);
+        break;
+      case METHOD_METR_CENTROID:
+        generic_linkage_vector_alternative<METHOD_VECTOR_CENTROID, T>(N, dist, Z2);
+        break;
+      default: // case METHOD_METR_MEDIAN:
+        generic_linkage_vector_alternative<METHOD_VECTOR_MEDIAN, T>(N, dist, Z2);
+      }
+
+      if (method == METHOD_METR_WARD || method == METHOD_METR_CENTROID) {
+        members.free();
+      }
+
+      dist.postprocess(Z2);
+
+      T *const Z_ = reinterpret_cast<T *>(PyArray_DATA(Z));
+      if (method != METHOD_METR_SINGLE) {
+        generate_SciPy_dendrogram<true, T>(Z_, Z2, N);
+      } else {
+        generate_SciPy_dendrogram<false, T>(Z_, Z2, N);
+      }
     }
   } // try
-  catch (const std::bad_alloc&) {
+  catch (const std::bad_alloc &) {
     return PyErr_NoMemory();
-  }
-  catch(const std::exception& e){
+  } catch (const std::exception &e) {
     PyErr_SetString(PyExc_EnvironmentError, e.what());
     return NULL;
-  }
-  catch(const nan_error&){
+  } catch (const nan_error &) {
     PyErr_SetString(PyExc_FloatingPointError, "NaN dissimilarity value.");
     return NULL;
-  }
-  catch(const pythonerror){
+  } catch (const pythonerror) {
     return NULL;
-  }
-  catch(...){
-    PyErr_SetString(PyExc_EnvironmentError,
-                    "C++ exception (unknown reason). Please send a bug report.");
+  } catch (...) {
+    PyErr_SetString(
+        PyExc_EnvironmentError,
+        "C++ exception (unknown reason). Please send a bug report.");
     return NULL;
   }
 #if HAVE_DIAGNOSTIC

--- a/src/fastcluster_python.cpp
+++ b/src/fastcluster_python.cpp
@@ -496,7 +496,7 @@ public:
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif
         V = reinterpret_cast<PyArrayObject *>(PyArray_FromAny(extraarg,
-                PyArray_DescrFromType(NPY_DOUBLE),
+                PyArray_DescrFromType(NPY_FLOAT),
                 1, 1,
                 NPY_ARRAY_CARRAY_RO,
                 NULL));
@@ -565,7 +565,7 @@ public:
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif
         V = reinterpret_cast<PyArrayObject *>(PyArray_FromAny(extraarg,
-              PyArray_DescrFromType(NPY_DOUBLE),
+              PyArray_DescrFromType(NPY_FLOAT),
               2, 2,
               NPY_ARRAY_CARRAY_RO,
               NULL));
@@ -796,7 +796,7 @@ private:
                       "The Minkowski metric needs a parameter.");
       throw pythonerror();
     }
-    postprocessarg = PyFloat_AsDouble(extraarg);
+    postprocessarg = static_cast<t_float>(PyFloat_AsDouble(extraarg));
     if (PyErr_Occurred()) {
       throw pythonerror();
     }
@@ -950,7 +950,7 @@ private:
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #endif
-    const t_float C_result = PyFloat_AsDouble(result);
+    const t_float C_result = static_cast<t_float>(PyFloat_AsDouble(result));
     Py_DECREF(result);
 #if HAVE_DIAGNOSTIC
 #pragma GCC diagnostic pop


### PR DESCRIPTION
This PR adds templating as suggested in issue #2. Hopefully it's still something that could be accepted! I ran into the same memory constraints which were described in the issue and figured I'd go ahead and try the templating implementation since it hadn't yet been addressed.

Now, someone can call: 
```
linkage(X, method='single', metric='euclidean', preserve_input=True, high_precision=True) 
```
which would result in the clustering using `np.double` dtype (by default, and as before).

Alternatively, if memory is an issue, a user can call:
```
linkage(X, method='single', metric='euclidean', preserve_input=True, high_precision=False)
```
which would result in the clustering using `np.single` dtype. 

In the end, I upcast `Z` back to `np.double` since that's the dtype expected in `fcluster`. 

Closes #2 
